### PR TITLE
WHFSPRT-108: Use the proper content type for ICAL link

### DIFF
--- a/CRM/Event/ICalendar.php
+++ b/CRM/Event/ICalendar.php
@@ -70,7 +70,7 @@ class CRM_Event_ICalendar extends CRM_Core_Page {
         CRM_Utils_ICalendar::send($calendar, 'text/xml', 'utf-8');
       }
       else {
-        CRM_Utils_ICalendar::send($calendar, 'text/plain', 'utf-8');
+        CRM_Utils_ICalendar::send($calendar, 'text/calendar', 'utf-8');
       }
     }
     else {

--- a/CRM/Utils/ICalendar.php
+++ b/CRM/Utils/ICalendar.php
@@ -85,8 +85,7 @@ class CRM_Utils_ICalendar {
 
   /**
    * Send the ICalendar to the browser with the specified content type
-   * - 'text/calendar' : used for downloaded ics file
-   * - 'text/plain'    : used for iCal formatted feed
+   * - 'text/calendar' : used for iCal formatted feed
    * - 'text/xml'      : used for gData or rss formatted feeds
    *
    *
@@ -106,7 +105,7 @@ class CRM_Utils_ICalendar {
     CRM_Utils_System::setHttpHeader("Content-Language", $lang);
     CRM_Utils_System::setHttpHeader("Content-Type", "$content_type; charset=$charset");
 
-    if ($content_type == 'text/calendar') {
+    if ($fileName !== NULL) {
       CRM_Utils_System::setHttpHeader('Content-Length', strlen($calendar));
       CRM_Utils_System::setHttpHeader("Content-Disposition", "$disposition; filename=\"$fileName\"");
       CRM_Utils_System::setHttpHeader("Pragma", "no-cache");


### PR DESCRIPTION

Before
----------------------------------------
When you click the `ICAL link` it shows the content and some users think it is a bug
![2020-12-30_09-35](https://user-images.githubusercontent.com/74309109/103336929-5956d980-4a82-11eb-9471-206c4881862f.png)
![Screenshot from 2020-12-30 09-42-54](https://user-images.githubusercontent.com/74309109/103337275-6fb16500-4a83-11eb-9bd1-1b927c3d56b2.png)


After
----------------------------------------
When you click the `ICAL link` the browser will start downloading the file.
![Screenshot from 2020-12-30 09-45-20](https://user-images.githubusercontent.com/74309109/103337373-c6b73a00-4a83-11eb-894d-ad02b33deb0a.png)


Technical Details
----------------------------------------
Using the proper content type for `ICAL link` is a good practice and the browsers will handle it properly by downloading it.
